### PR TITLE
Set 'Vary' header and HTTP 401 on policy violation.

### DIFF
--- a/src/Enforce_Policies.php
+++ b/src/Enforce_Policies.php
@@ -69,7 +69,7 @@ class Enforce_Policies {
 		$option   = $this->policies_setting->get();
 		$headers  = getallheaders();
 
-		if ( 0 === $this->enforced_policies++
+		if ( 0 === $this->enforced_policies
 		// Browser supports Fetch Metadata.
 		&& isset( $headers[ Isolation_Policy::SITE ] ) ) {
 			foreach ( $option as $policy_slug => $policy_status_array ) {
@@ -101,6 +101,7 @@ class Enforce_Policies {
 					// TODO: Add reporting.
 					continue;
 				}
+				$this->enforced_policies++;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 5.0 and PHP 5.6.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Set `Vary` response header when at least one policy is active.
* Use HTTP status code 401 on policy violation.
